### PR TITLE
Fixed application of cookie expiry for remember me

### DIFF
--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -57,7 +57,7 @@ function Login(props) {
             .post('/auth/generate-token/', form)
             .then((response) => {
                 Cookies.set('token', response.data.token, {
-                    expires: response.data.expires,
+                    expires: form.remember ? null : 1 / 24,
                 });
                 console.log(response);
             })


### PR DESCRIPTION
- Changed cookie so that it lasts until the user closes the browser (remember = true), or one hour (remember = false)